### PR TITLE
Manual commit isn't needed when default transaction is enabled [RHCLOUD-20590]

### DIFF
--- a/internal/endpoints/github.go
+++ b/internal/endpoints/github.go
@@ -65,7 +65,6 @@ func GithubWebhook(w http.ResponseWriter, r *http.Request) {
 					writeResponse(w, http.StatusInternalServerError, `{"msg": "Failed to insert webhook data"}`)
 					return
 				}
-				db.DB.Commit()
 				l.Log.Infof("Created %d commit entries for %s", len(commitData), key)
 				writeResponse(w, http.StatusOK, `{"msg": "ok"}`)
 				return

--- a/internal/endpoints/gitlab.go
+++ b/internal/endpoints/gitlab.go
@@ -145,7 +145,6 @@ func GitlabWebhook(w http.ResponseWriter, r *http.Request) {
 					writeResponse(w, http.StatusInternalServerError, `{"msg": "Failed to insert webhook data"}`)
 					return
 				}
-				db.DB.Commit()
 				l.Log.Infof("Created %d commit entries for %s", len(commitData), key)
 				writeResponse(w, http.StatusOK, `{"msg": "ok"}`)
 				return


### PR DESCRIPTION
We don't need to explicitly commit db transaction if default transaction is enabled. This is most likely why the db was crashing when we register the webhooks.

Gorm doc: [Here](https://gorm.io/docs/transactions.html#Disable-Default-Transaction)