### PR TITLE
[fix] ensure schema is available in image

### DIFF
--- a/build/Containerfile
+++ b/build/Containerfile
@@ -16,6 +16,7 @@ WORKDIR /
 
 COPY --from=builder /go/src/app/platform-changelog-api ./platform-changelog-api
 COPY --from=builder /go/src/app/platform-changelog-migrate ./platform-changelog-migrate
+COPY --from=builder /go/src/app/schema/openapi.yaml ./schema/openapi.yaml
 
 # install postgresql from centos if not building on RHSM system
 RUN FULL_RHEL=$(microdnf repolist --enabled | grep rhel-8) ; \


### PR DESCRIPTION
Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

We need to make sure the schema is in the right place for when the container tries to start
