### PR TITLE
[RHCLOUD-22714] Tenant field

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,24 @@ TODO: API Spec
 
 To add a service to be supported by platform-changelog, follow these steps:
 
-1. Add the service to `internal/config/services.yaml`
+1. Add your tenant to `internal/config/tenant.yaml` if it is not included.
+  ```yaml
+  tenant-name:
+    name: Tenant Name
+```
+
+2. Add the service to `internal/config/services.yaml`.
   
   ```yaml
   service-name:
     display_name: "Service Name"
+    tenant: <tenant>
     gh_repo: <https://github.com/org/repo>
     branch: master # branch to be monitored
     namespace: <namespace of the project>
 ```
 
-2. Submit an MR to this repo. It will be approved by an owner
+3. Submit an MR to this repo. It will be approved by an owner.
 
 ## Development
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,9 +1,9 @@
 package config
 
 import (
+	"encoding/json"
 	"os"
 	"strings"
-	"encoding/json"
 
 	_ "embed"
 
@@ -14,6 +14,9 @@ import (
 
 //go:embed services.yaml
 var services []byte
+
+//go:embed tenant.yaml
+var tenants []byte
 
 type Config struct {
 	PublicPort             string
@@ -26,8 +29,9 @@ type Config struct {
 	GithubWebhookSecretKey string
 	GitlabWebhookSecretKey string
 	Services               map[string]Service
+	Tenants                map[string]Tenant
 	Debug                  bool
-	OpenAPISpec			   []byte
+	OpenAPISpec            []byte
 }
 
 type DatabaseCfg struct {
@@ -48,11 +52,16 @@ type CloudwatchCfg struct {
 
 type Service struct {
 	DisplayName string `yaml:"display_name"`
+	Tenant      string `yaml:"tenant"`
 	GHRepo      string `yaml:"gh_repo,omitempty"`
 	GLRepo      string `yaml:"gl_repo,omitempty"`
 	Branch      string `yaml:"branch"`
 	Namespace   string `yaml:"namespace,omitempty"`
 	DeployFile  string `yaml:"deploy_file,omitempty"`
+}
+
+type Tenant struct {
+	Name string `yaml:"name"`
 }
 
 func readOpenAPISpec() []byte {
@@ -176,6 +185,12 @@ func Get() *Config {
 	err = yaml.Unmarshal(services, config)
 	if err != nil {
 		panic("Unable to read services.yaml")
+	}
+
+	// read in tenant.yaml to the config
+	err = yaml.Unmarshal(tenants, config)
+	if err != nil {
+		panic("Unable to read tenants.yaml")
 	}
 
 	return config

--- a/internal/config/services.yaml
+++ b/internal/config/services.yaml
@@ -1,21 +1,25 @@
 services:
   rbac:
     display_name: RBAC
+    tenant: Insights
     gh_repo: https://github.com/RedHatInsights/insights-rbac
     branch: master
     namespace: rbac-prod
   entitlements:
     display_name: Entitlements
+    tenant: Insights
     gh_repo: https://github.com/RedHatInsights/entitlements-api-go
     branch: master
     namespace: entitlements-prod
   ingress:
     display_name: Ingress
+    tenant: Insights
     gh_repo: https://github.com/RedHatInsights/insights-ingress-go
     branch: master
     namespace: ingress-prod
   insights-engine:
     display_name: Insights Engine
+    tenant: Insights
     gl_repo: https://gitlab.cee.redhat.com/insights-platform/insights-engine
     branch: master 
     namespace: engine-prod

--- a/internal/config/tenant.yaml
+++ b/internal/config/tenant.yaml
@@ -1,0 +1,9 @@
+---
+# Validated tenants, list each tenant name as a string
+tenants:
+  insights:
+    name: Insights
+  ansible: 
+    name: Ansible
+  ocm:
+    name: OCM

--- a/internal/db/services.go
+++ b/internal/db/services.go
@@ -11,7 +11,7 @@ import (
 )
 
 func CreateServiceTableEntry(db *gorm.DB, name string, s config.Service) (result *gorm.DB, service models.Services) {
-	newService := models.Services{Name: name, DisplayName: s.DisplayName, GHRepo: s.GHRepo, GLRepo: s.GLRepo, Branch: s.Branch, Namespace: s.Namespace, DeployFile: s.DeployFile}
+	newService := models.Services{Name: name, DisplayName: s.DisplayName, Tenant: s.Tenant, GHRepo: s.GHRepo, GLRepo: s.GLRepo, Branch: s.Branch, Namespace: s.Namespace, DeployFile: s.DeployFile}
 	results := db.Create(&newService)
 	return results, newService
 }

--- a/internal/migration/main.go
+++ b/internal/migration/main.go
@@ -31,6 +31,12 @@ func main() {
 
 func reconcileServices(g *gorm.DB, cfg *config.Config) {
 	for key, service := range cfg.Services {
+		// Validate the tenant field exists in the config
+		if !validateTenant(service.Tenant, cfg) {
+			logging.Log.Error("Tenant not validated: ", service.Tenant)
+			continue
+		}
+
 		res, _ := db.GetServiceByName(g, key)
 		if res.RowsAffected == 0 {
 			_, service := db.CreateServiceTableEntry(g, key, service)
@@ -39,4 +45,13 @@ func reconcileServices(g *gorm.DB, cfg *config.Config) {
 			logging.Log.Info("Service already exists: ", service.DisplayName)
 		}
 	}
+}
+
+func validateTenant(tenant string, cfg *config.Config) bool {
+	for _, t := range cfg.Tenants {
+		if t.Name == tenant {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -8,6 +8,7 @@ type Services struct {
 	ID          int    `gorm:"primary_key;autoincremement"`
 	Name        string `gorm:"not null"`
 	DisplayName string `gorm:"not null;unique"`
+	Tenant      string `gorm:"not null"`
 	GHRepo      string
 	GLRepo      string
 	DeployFile  string

--- a/internal/structs/structs.go
+++ b/internal/structs/structs.go
@@ -25,6 +25,7 @@ type ServicesData struct {
 	ID          int    `json:"id"`
 	Name        string `json:"name"`
 	DisplayName string `json:"display_name"`
+	Tenant      string `json:"tenant"`
 	GHRepo      string `json:"gh_repo"`
 	GLRepo      string `json:"gl_repo"`
 	DeployFile  string `json:"deploy_file"`
@@ -36,6 +37,7 @@ type ExpandedServicesData struct {
 	ID          int              `json:"id"`
 	Name        string           `json:"name"`
 	DisplayName string           `json:"display_name"`
+	Tenant      string           `json:"tenant"`
 	GHRepo      string           `json:"gh_repo"`
 	GLRepo      string           `json:"gl_repo"`
 	DeployFile  string           `json:"deploy_file"`

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -338,6 +338,9 @@ components:
         display_name:
           type: string
           description: Preferred name
+        tenant:
+          type: string
+          description: Tenant the service belongs to
         gh_repo:
           type: string
           description: Github repo url


### PR DESCRIPTION
### Changes
* Added tenant field to services
* Reads from tenant.yml, which will be a source of truth for the field
* The validation is currently pretty simple, if it exists in the tenant.yml, the service can be created.

**Issues for later**
* This does make me remember some problems with our migrations/seeding:
  * If a service with the service name exists, the service will not be updated. If one moved to a different tenant, for example, that could be a headache.
  * Since we try to get the tenant before creating it, we get db errors form accessing services that aren't there.
  * Timelines have a type enum field, which is created by a SQL command. If the enum already exists, we get a db duplicate error.
* I'll add this field to the filtering PR once it goes through.