### PR TITLE
[RHCLOUD-23617] Corrected Find to Model function for Counts

### DIFF
--- a/internal/db/commits.go
+++ b/internal/db/commits.go
@@ -42,7 +42,7 @@ func (conn *DBConnectorImpl) GetCommitsAll(offset int, limit int, q structs.Quer
 
 	db = FilterTimelineByDate(db, q.StartDate, q.EndDate)
 
-	db.Find(&commits).Count(&count)
+	db.Model(&commits).Count(&count)
 	result := db.Order("Timestamp desc").Limit(limit).Offset(offset).Find(&commits)
 
 	return commits, count, result.Error
@@ -59,7 +59,7 @@ func (conn *DBConnectorImpl) GetCommitsByService(service structs.ServicesData, o
 
 	db = FilterTimelineByDate(db, q.StartDate, q.EndDate)
 
-	db.Find(&commits).Count(&count)
+	db.Model(&commits).Count(&count)
 	result := db.Order("Timestamp desc").Limit(limit).Offset(offset).Find(&commits)
 
 	return commits, count, result.Error

--- a/internal/db/deploys.go
+++ b/internal/db/deploys.go
@@ -31,7 +31,7 @@ func (conn *DBConnectorImpl) GetDeploysAll(offset int, limit int, q structs.Quer
 
 	db = FilterTimelineByDate(db, q.StartDate, q.EndDate)
 
-	db.Find(&deploys).Count(&count)
+	db.Model(&deploys).Count(&count)
 	result := db.Order("Timestamp desc").Limit(limit).Offset(offset).Find(&deploys)
 
 	return deploys, count, result.Error
@@ -48,7 +48,7 @@ func (conn *DBConnectorImpl) GetDeploysByService(service structs.ServicesData, o
 
 	db = FilterTimelineByDate(db, q.StartDate, q.EndDate)
 
-	db.Find(&deploys).Count(&count)
+	db.Model(&deploys).Count(&count)
 	result := db.Order("Timestamp desc").Limit(limit).Offset(offset).Find(&deploys)
 
 	return deploys, count, result.Error

--- a/internal/db/services.go
+++ b/internal/db/services.go
@@ -41,7 +41,8 @@ func (conn *DBConnectorImpl) GetServicesAll(offset int, limit int, q structs.Que
 		db = db.Where("services.branch IN ?", q.ServiceBranch)
 	}
 
-	db.Find(&services).Count(&count)
+	// Uses the Services model here to reflect the proper db relation
+	db.Model(models.Services{}).Count(&count)
 
 	result := db.Limit(limit).Offset(offset).Find(&services)
 

--- a/internal/db/timelines.go
+++ b/internal/db/timelines.go
@@ -34,7 +34,7 @@ func (conn *DBConnectorImpl) GetTimelinesAll(offset int, limit int, q structs.Qu
 
 	db = FilterTimelineByDate(db, q.StartDate, q.EndDate)
 
-	db.Find(&timelines).Count(&count)
+	db.Model(&timelines).Count(&count)
 	result := conn.db.Order("Timestamp desc").Limit(limit).Offset(offset).Find(&timelines)
 
 	return timelines, count, result.Error
@@ -54,7 +54,7 @@ func (conn *DBConnectorImpl) GetTimelinesByService(service structs.ServicesData,
 
 	db = FilterTimelineByDate(db, q.StartDate, q.EndDate)
 
-	db.Find(&timelines).Count(&count)
+	db.Model(&timelines).Count(&count)
 	result := conn.db.Order("Timestamp desc").Limit(limit).Offset(offset).Find(&timelines)
 
 	return timelines, count, result.Error


### PR DESCRIPTION
### Changes

As Derek found with Payload Tracker, the Find gorm function loads the whole DB table into memory when finding the count (which could cause an OOM error). Changed all references to Find().Count() to Model().Count().