### PR TITLE
Route change for 3scale

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,15 +41,15 @@ check-db:
 
 test-github-webhook:
 
-	curl -X POST -H "X-Github-Event: push" -H "Content-Type: application/json" --data "@tests/github_webhook.json" http://localhost:8000/api/v1/github-webhook
+	curl -X POST -H "X-Github-Event: push" -H "Content-Type: application/json" --data "@tests/github_webhook.json" http://localhost:8000/api/platform-changelog/v1/github-webhook
 
 test-gitlab-webhook:
 
-	curl -X POST -H "X-Gitlab-Event: Push Hook" -H "Content-Type: application/json" --data "@tests/gitlab_webhook.json" http://localhost:8000/api/v1/gitlab-webhook
+	curl -X POST -H "X-Gitlab-Event: Push Hook" -H "Content-Type: application/json" --data "@tests/gitlab_webhook.json" http://localhost:8000/api/platform-changelog/v1/gitlab-webhook
 
 test-tekton-task:
 
-	curl -X POST http://localhost:8000/api/v1/tekton --data "@tests/tekton/valid.json" -H "Content-Type: application/json"
+	curl -X POST http://localhost:8000/api/platform-changelog/v1/tekton --data "@tests/tekton/valid.json" -H "Content-Type: application/json"
 
 compose:
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To send the webhook, you can use curl or `make test-github-webhook`. The curl co
 
 `curl -X POST -H "X-Github-Event: push" -H "Content-Type: application/json" --data "@tests/github_webhook.json" http://localhost:8000/api/platform-changelog/v1/github-webhook`
 
-From there, you should be able to open a browser and see the results at: http://localhost:8000/api/v1/commits. There should be commits matching the webhook data that was sent.
+From there, you should be able to open a browser and see the results at: http://localhost:8000/api/platform-changelog/v1/commits. There should be commits matching the webhook data that was sent.
 
 ## Running Tests
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Note: The `DEBUG` argument allows us to send webhooks without needing the secret
 Note: This is useful to avoid having to run the database locally, but this will not persist data between runs.
 
 The API should now be up and available on `localhost:8000`. You should be able to
-see the API in action by visiting `http://localhost:8000/api/v1/services`.
+see the API in action by visiting `http://localhost:8000/api/platform-changelog/v1/services`.
 
 ### Testing Webhooks to the API Manually
 
@@ -88,7 +88,7 @@ Test webhook json is provided in the `tests` directory in this repo.
 
 To send the webhook, you can use curl or `make test-github-webhook`. The curl command is:
 
-`curl -X POST -H "X-Github-Event: push" -H "Content-Type: application/json" --data "@tests/github_webhook.json" http://localhost:8000/api/v1/github-webhook`
+`curl -X POST -H "X-Github-Event: push" -H "Content-Type: application/json" --data "@tests/github_webhook.json" http://localhost:8000/api/platform-changelog/v1/github-webhook`
 
 From there, you should be able to open a browser and see the results at: http://localhost:8000/api/v1/commits. There should be commits matching the webhook data that was sent.
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -34,7 +34,7 @@ func main() {
 	mr := chi.NewRouter()
 	sub := chi.NewRouter().With(metrics.ResponseMetricsMiddleware)
 
-	// Mount the root of the api router on /api/v1
+	// Mount the root of the api router on /api/platform-changelog/v1
 	r.Mount("/api/platform-changelog/v1", sub)
 	r.Get("/", handler.LubdubHandler)
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -35,7 +35,7 @@ func main() {
 	sub := chi.NewRouter().With(metrics.ResponseMetricsMiddleware)
 
 	// Mount the root of the api router on /api/v1
-	r.Mount("/api/v1", sub)
+	r.Mount("/api/platform-changelog/v1", sub)
 	r.Get("/", handler.LubdubHandler)
 
 	mr.Get("/", handler.LubdubHandler)

--- a/internal/endpoints/tekton_test.go
+++ b/internal/endpoints/tekton_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Handler", func() {
 			handler := endpoints.NewHandler(dbConnector)
 
 			// create a request
-			req, err := http.NewRequest("POST", "/api/v1/tekton", nil)
+			req, err := http.NewRequest("POST", "/api/platform-changelog/v1/tekton", nil)
 			Expect(err).To(BeNil())
 
 			req.Header.Set("Content-Type", "application/json")
@@ -37,7 +37,7 @@ var _ = Describe("Handler", func() {
 			rr := httptest.NewRecorder()
 
 			router := chi.NewRouter()
-			router.Post("/api/v1/tekton", handler.TektonTaskRun)
+			router.Post("/api/platform-changelog/v1/tekton", handler.TektonTaskRun)
 
 			router.ServeHTTP(rr, req)
 
@@ -62,7 +62,7 @@ var _ = Describe("Handler", func() {
 		handler := endpoints.NewHandler(dbConnector)
 
 		// create a request
-		req, err := http.NewRequest("POST", "/api/v1/tekton", f)
+		req, err := http.NewRequest("POST", "/api/platform-changelog/v1/tekton", f)
 		Expect(err).To(BeNil())
 
 		req.Header.Set("Content-Type", "application/json")
@@ -70,7 +70,7 @@ var _ = Describe("Handler", func() {
 		rr := httptest.NewRecorder()
 
 		router := chi.NewRouter()
-		router.Post("/api/v1/tekton", handler.TektonTaskRun)
+		router.Post("/api/platform-changelog/v1/tekton", handler.TektonTaskRun)
 
 		router.ServeHTTP(rr, req)
 


### PR DESCRIPTION
Ticket: [RHCLOUD-23774](https://issues.redhat.com/browse/RHCLOUD-23774)

3scale needs to api in the format of /api/app-name/v1 to be accessible.