### PR TITLE
Order by ID desc

### DIFF
--- a/internal/db/commits.go
+++ b/internal/db/commits.go
@@ -43,7 +43,7 @@ func (conn *DBConnectorImpl) GetCommitsAll(offset int, limit int, q structs.Quer
 	db = FilterTimelineByDate(db, q.StartDate, q.EndDate)
 
 	db.Model(&commits).Count(&count)
-	result := db.Order("Timestamp desc").Limit(limit).Offset(offset).Find(&commits)
+	result := db.Order("Timestamp desc").Order("ID desc").Limit(limit).Offset(offset).Find(&commits)
 
 	return commits, count, result.Error
 }
@@ -60,7 +60,7 @@ func (conn *DBConnectorImpl) GetCommitsByService(service structs.ServicesData, o
 	db = FilterTimelineByDate(db, q.StartDate, q.EndDate)
 
 	db.Model(&commits).Count(&count)
-	result := db.Order("Timestamp desc").Limit(limit).Offset(offset).Find(&commits)
+	result := db.Order("Timestamp desc").Order("ID desc").Limit(limit).Offset(offset).Find(&commits)
 
 	return commits, count, result.Error
 }

--- a/internal/db/deploys.go
+++ b/internal/db/deploys.go
@@ -39,7 +39,7 @@ func (conn *DBConnectorImpl) GetDeploysAll(offset int, limit int, q structs.Quer
 	db = FilterTimelineByDate(db, q.StartDate, q.EndDate)
 
 	db.Model(&deploys).Count(&count)
-	result := db.Order("Timestamp desc").Limit(limit).Offset(offset).Find(&deploys)
+	result := db.Order("Timestamp desc").Order("ID desc").Limit(limit).Offset(offset).Find(&deploys)
 
 	return deploys, count, result.Error
 }
@@ -56,7 +56,7 @@ func (conn *DBConnectorImpl) GetDeploysByService(service structs.ServicesData, o
 	db = FilterTimelineByDate(db, q.StartDate, q.EndDate)
 
 	db.Model(&deploys).Count(&count)
-	result := db.Order("Timestamp desc").Limit(limit).Offset(offset).Find(&deploys)
+	result := db.Order("Timestamp desc").Order("ID desc").Limit(limit).Offset(offset).Find(&deploys)
 
 	return deploys, count, result.Error
 }

--- a/internal/db/services.go
+++ b/internal/db/services.go
@@ -44,7 +44,8 @@ func (conn *DBConnectorImpl) GetServicesAll(offset int, limit int, q structs.Que
 	// Uses the Services model here to reflect the proper db relation
 	db.Model(models.Services{}).Count(&count)
 
-	result := db.Limit(limit).Offset(offset).Find(&services)
+	// TODO: add a sort_by field to the query struct
+	result := db.Order("ID desc").Limit(limit).Offset(offset).Find(&services)
 
 	var servicesWithTimelines []structs.ExpandedServicesData
 	for i := 0; i < len(services); i++ {

--- a/internal/db/timelines.go
+++ b/internal/db/timelines.go
@@ -35,7 +35,7 @@ func (conn *DBConnectorImpl) GetTimelinesAll(offset int, limit int, q structs.Qu
 	db = FilterTimelineByDate(db, q.StartDate, q.EndDate)
 
 	db.Model(&timelines).Count(&count)
-	result := conn.db.Order("Timestamp desc").Limit(limit).Offset(offset).Find(&timelines)
+	result := conn.db.Order("Timestamp desc").Order("ID desc").Limit(limit).Offset(offset).Find(&timelines)
 
 	return timelines, count, result.Error
 }
@@ -55,7 +55,7 @@ func (conn *DBConnectorImpl) GetTimelinesByService(service structs.ServicesData,
 	db = FilterTimelineByDate(db, q.StartDate, q.EndDate)
 
 	db.Model(&timelines).Count(&count)
-	result := db.Order("Timestamp desc").Limit(limit).Offset(offset).Find(&timelines)
+	result := db.Order("Timestamp desc").Order("ID desc").Limit(limit).Offset(offset).Find(&timelines)
 
 	return timelines, count, result.Error
 }


### PR DESCRIPTION
Quirk Brandon found: the timestamp ordering works as you expect, but when multiple entries have the same timestamp, they are in an odd order.