### PR TITLE
Correcting deployment commands

### DIFF
--- a/deployment/clowdapp.yml
+++ b/deployment/clowdapp.yml
@@ -23,14 +23,18 @@ objects:
       podSpec:
         initContainers:
           - command:
-            - platform-changelog migrate && platform-changelog seed
+            - ./platform-changelog
+            - migrate
+            - && 
+            - ./platform-changelog 
+            - seed
             image: ${IMAGE}:${IMAGE_TAG}
             inheritEnv: True
         minReadySeconds: 15
         progressDeadlineSeconds: 600
         image: ${IMAGE}:${IMAGE_TAG}
         command:
-          - platform-changelog
+          - ./platform-changelog
           - api
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
The container is failing to load because it can't find the executable.

`Error: container create failed: time="2023-08-02T18:44:50Z" level=error msg="runc create failed: unable to start container process: exec: \"platform-changelog migrate && platform-changelog seed\": executable file not found in $PATH" `