### PR TITLE
Ordering down migrate better

### DIFF
--- a/migrations/001_initial.down.sql
+++ b/migrations/001_initial.down.sql
@@ -1,6 +1,7 @@
 DROP SEQUENCE services_id_seq CASCADE;
-DROP TABLE services;
 
 DROP SEQUENCE timelines_id_seq CASCADE;
 DROP TABLE timelines;
 DROP TYPE timeline_type;
+
+DROP TABLE services;


### PR DESCRIPTION
Whenever I ran the migration down, it left the services table. This fixes that.

Also want the init container to restart.