### PR TITLE
Start separating structs that are used in the database layer from structs that are used in the web/rest api layer

### DIFF
--- a/cmd/seed.go
+++ b/cmd/seed.go
@@ -1,11 +1,10 @@
 package main
 
 import (
-	"github.com/redhatinsights/platform-changelog-go/internal/structs"
-
 	"github.com/redhatinsights/platform-changelog-go/internal/config"
 	"github.com/redhatinsights/platform-changelog-go/internal/db"
 	"github.com/redhatinsights/platform-changelog-go/internal/logging"
+	"github.com/redhatinsights/platform-changelog-go/internal/models"
 )
 
 func seedDB(cfg *config.Config) {
@@ -65,7 +64,7 @@ func validateTenant(tenant string, cfg *config.Config) bool {
 
 // Compare the services in the DB to the services in the config
 // Returns false is they are the same, true if they are different
-func compareService(fromDB structs.ServicesData, fromCfg config.Service) bool {
+func compareService(fromDB models.Services, fromCfg config.Service) bool {
 	if fromDB.DisplayName != fromCfg.DisplayName ||
 		fromDB.Tenant != fromCfg.Tenant {
 		// TODO: bulk update services

--- a/internal/db/commits.go
+++ b/internal/db/commits.go
@@ -57,7 +57,7 @@ func (conn *DBConnectorImpl) GetCommitsAll(offset int, limit int, q structs.Quer
 	return commits, count, result.Error
 }
 
-func (conn *DBConnectorImpl) GetCommitsByService(service structs.ServicesData, offset int, limit int, q structs.Query) ([]models.Timelines, int64, error) {
+func (conn *DBConnectorImpl) GetCommitsByService(service models.Services, offset int, limit int, q structs.Query) ([]models.Timelines, int64, error) {
 	callDurationTimer := prometheus.NewTimer(metrics.SqlGetCommitsByService)
 	defer callDurationTimer.ObserveDuration()
 

--- a/internal/db/deploys.go
+++ b/internal/db/deploys.go
@@ -44,7 +44,7 @@ func (conn *DBConnectorImpl) GetDeploysAll(offset int, limit int, q structs.Quer
 	return deploys, count, result.Error
 }
 
-func (conn *DBConnectorImpl) GetDeploysByService(service structs.ServicesData, offset int, limit int, q structs.Query) ([]models.Timelines, int64, error) {
+func (conn *DBConnectorImpl) GetDeploysByService(service models.Services, offset int, limit int, q structs.Query) ([]models.Timelines, int64, error) {
 	callDurationTimer := prometheus.NewTimer(metrics.SqlGetDeploysByService)
 	defer callDurationTimer.ObserveDuration()
 

--- a/internal/db/projects.go
+++ b/internal/db/projects.go
@@ -49,7 +49,7 @@ func (conn *DBConnectorImpl) GetProjectsAll(offset int, limit int, q structs.Que
 	return projects, count, result.Error
 }
 
-func (conn *DBConnectorImpl) GetProjectsByService(service structs.ServicesData, offset int, limit int, q structs.Query) ([]structs.ProjectsData, int64, error) {
+func (conn *DBConnectorImpl) GetProjectsByService(service models.Services, offset int, limit int, q structs.Query) ([]structs.ProjectsData, int64, error) {
 	callDurationTimer := prometheus.NewTimer(metrics.SqlGetProjectsByService)
 	defer callDurationTimer.ObserveDuration()
 

--- a/internal/db/services.go
+++ b/internal/db/services.go
@@ -22,19 +22,19 @@ func (conn *DBConnectorImpl) UpdateServiceTableEntry(name string, s config.Servi
 	return newService, results.Error
 }
 
-func (conn *DBConnectorImpl) DeleteServiceTableEntry(name string) (structs.ServicesData, error) {
+func (conn *DBConnectorImpl) DeleteServiceTableEntry(name string) (models.Services, error) {
 	// save the service to delete the timelines
 	service, _, _ := conn.GetServiceByName(name)
 
 	results := conn.db.Model(models.Services{}).Where("name = ?", name).Delete(&models.Services{})
 	if results.Error != nil {
-		return structs.ServicesData{}, results.Error
+		return models.Services{}, results.Error
 	}
 
 	// delete the timelines for the service
 	err := conn.DeleteTimelinesByService(service)
 	if err != nil {
-		return structs.ServicesData{}, err
+		return models.Services{}, err
 	}
 
 	return service, results.Error
@@ -126,13 +126,12 @@ func (conn *DBConnectorImpl) GetServiceByNameWorkin(name string) (structs.Servic
 	return s, result.RowsAffected, result.Error
 }
 
-func (conn *DBConnectorImpl) GetServiceByName(name string) (structs.ServicesData, int64, error) {
+func (conn *DBConnectorImpl) GetServiceByName(name string) (models.Services, int64, error) {
 	callDurationTimer := prometheus.NewTimer(metrics.SqlGetServiceByName)
 	defer callDurationTimer.ObserveDuration()
 
-	var service structs.ServicesData
+	var service models.Services
 	result := conn.db.Model(models.Services{}).Preload("Projects").First(&service)
-
 	return service, result.RowsAffected, result.Error
 }
 

--- a/internal/db/timelines.go
+++ b/internal/db/timelines.go
@@ -40,7 +40,7 @@ func (conn *DBConnectorImpl) GetTimelinesAll(offset int, limit int, q structs.Qu
 	return timelines, count, result.Error
 }
 
-func (conn *DBConnectorImpl) GetTimelinesByService(service structs.ServicesData, offset int, limit int, q structs.Query) ([]models.Timelines, int64, error) {
+func (conn *DBConnectorImpl) GetTimelinesByService(service models.Services, offset int, limit int, q structs.Query) ([]models.Timelines, int64, error) {
 	callDurationTimer := prometheus.NewTimer(metrics.SqlGetTimelinesByService)
 	defer callDurationTimer.ObserveDuration()
 
@@ -91,7 +91,7 @@ func (conn *DBConnectorImpl) GetTimelineByRef(ref string) (models.Timelines, int
 	return timeline, result.RowsAffected, result.Error
 }
 
-func (conn *DBConnectorImpl) DeleteTimelinesByService(service structs.ServicesData) error {
+func (conn *DBConnectorImpl) DeleteTimelinesByService(service models.Services) error {
 	result := conn.db.Model(models.Timelines{}).Where("service_id = ?", service.ID).Delete(&models.Timelines{})
 
 	return result.Error

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -9,35 +9,35 @@ import (
 type DBConnector interface {
 	CreateServiceTableEntry(s models.Services) (models.Services, error)
 	UpdateServiceTableEntry(name string, s config.Service) (service models.Services, err error)
-	DeleteServiceTableEntry(name string) (structs.ServicesData, error)
+	DeleteServiceTableEntry(name string) (models.Services, error)
 	GetServicesAll(offset int, limit int, q structs.Query) ([]structs.ExpandedServicesData, int64, error)
 	GetLatest(service structs.ExpandedServicesData) (structs.ExpandedServicesData, error, error)
-	GetServiceByName(name string) (structs.ServicesData, int64, error)
+	GetServiceByName(name string) (models.Services, int64, error)
 	GetServiceByRepo(repo string) (structs.ServicesData, error)
 
 	CreateProjectTableEntry(p models.Projects) (err error)
 	UpdateProjectTableEntry(p structs.ProjectsData) (project models.Projects, err error)
 	GetProjectsAll(offset int, limit int, q structs.Query) ([]structs.ProjectsData, int64, error)
-	GetProjectsByService(service structs.ServicesData, offset int, limit int, q structs.Query) ([]structs.ProjectsData, int64, error)
+	GetProjectsByService(service models.Services, offset int, limit int, q structs.Query) ([]structs.ProjectsData, int64, error)
 	GetProjectByName(name string) (structs.ProjectsData, int64, error)
 	GetProjectByRepo(repo string) (structs.ProjectsData, error)
 
 	GetTimelinesAll(offset int, limit int, q structs.Query) ([]models.Timelines, int64, error)
-	GetTimelinesByService(service structs.ServicesData, offset int, limit int, q structs.Query) ([]models.Timelines, int64, error)
+	GetTimelinesByService(service models.Services, offset int, limit int, q structs.Query) ([]models.Timelines, int64, error)
 	GetTimelinesByProject(project structs.ProjectsData, offset int, limit int, q structs.Query) ([]models.Timelines, int64, error)
 	GetTimelineByRef(ref string) (models.Timelines, int64, error)
-	DeleteTimelinesByService(service structs.ServicesData) error
+	DeleteTimelinesByService(service models.Services) error
 
 	CreateCommitEntry(timeline models.Timelines) error
 	BulkCreateCommitEntry(timeline []models.Timelines) error
 	GetCommitsAll(offset int, limit int, q structs.Query) ([]models.Timelines, int64, error)
-	GetCommitsByService(service structs.ServicesData, offset int, limit int, q structs.Query) ([]models.Timelines, int64, error)
+	GetCommitsByService(service models.Services, offset int, limit int, q structs.Query) ([]models.Timelines, int64, error)
 	GetCommitsByProject(project structs.ProjectsData, offset int, limit int, q structs.Query) ([]models.Timelines, int64, error)
 	GetCommitByRef(ref string) (models.Timelines, int64, error)
 
 	CreateDeployEntry(timeline models.Timelines) error
 	GetDeploysAll(offset int, limit int, q structs.Query) ([]models.Timelines, int64, error)
-	GetDeploysByService(service structs.ServicesData, offset int, limit int, q structs.Query) ([]models.Timelines, int64, error)
+	GetDeploysByService(service models.Services, offset int, limit int, q structs.Query) ([]models.Timelines, int64, error)
 	GetDeploysByProject(project structs.ProjectsData, offset int, limit int, q structs.Query) ([]models.Timelines, int64, error)
 	GetDeployByRef(ref string) (models.Timelines, int64, error)
 }

--- a/internal/endpoints/github.go
+++ b/internal/endpoints/github.go
@@ -152,14 +152,14 @@ func validateGithubPayload(payload GithubPayload) error {
 	return nil
 }
 
-func getServiceAndProject(conn db.DBConnector, payload GithubPayload) (service structs.ServicesData, project structs.ProjectsData, err1 error, err2 error) {
+func getServiceAndProject(conn db.DBConnector, payload GithubPayload) (service models.Services, project structs.ProjectsData, err1 error, err2 error) {
 	service, _, err1 = conn.GetServiceByName(payload.App)
 	project, _, err2 = conn.GetProjectByName(payload.Project)
 
 	return
 }
 
-func createNewService(conn db.DBConnector, payload GithubPayload) (service structs.ServicesData, err error) {
+func createNewService(conn db.DBConnector, payload GithubPayload) (service models.Services, err error) {
 	// couldn't find service; create it, then handle the project
 	s := models.Services{
 		Name:        payload.App,
@@ -169,14 +169,14 @@ func createNewService(conn db.DBConnector, payload GithubPayload) (service struc
 
 	_, err = conn.CreateServiceTableEntry(s)
 	if err != nil {
-		return structs.ServicesData{}, fmt.Errorf("problem creating service %s", payload.App)
+		return models.Services{}, fmt.Errorf("problem creating service %s", payload.App)
 	}
 
 	service, _, err = conn.GetServiceByName(payload.App)
 	return
 }
 
-func createNewProject(conn db.DBConnector, payload GithubPayload, service structs.ServicesData) (project structs.ProjectsData, err error) {
+func createNewProject(conn db.DBConnector, payload GithubPayload, service models.Services) (project structs.ProjectsData, err error) {
 	p := models.Projects{
 		ServiceID: service.ID,
 		Name:      payload.Project,
@@ -194,7 +194,7 @@ func createNewProject(conn db.DBConnector, payload GithubPayload, service struct
 }
 
 // Converting from GithubPayload struct to Timeline model
-func convertGithubPayloadToTimelines(conn db.DBConnector, payload GithubPayload, service structs.ServicesData, project structs.ProjectsData) (commit models.Timelines, err error) {
+func convertGithubPayloadToTimelines(conn db.DBConnector, payload GithubPayload, service models.Services, project structs.ProjectsData) (commit models.Timelines, err error) {
 	// author, timestamp, mergedby, and message will be updated with information from github api
 
 	t := models.Timelines{

--- a/internal/structs/structs.go
+++ b/internal/structs/structs.go
@@ -1,8 +1,6 @@
 package structs
 
 import (
-	"fmt"
-
 	"github.com/redhatinsights/platform-changelog-go/internal/models"
 )
 
@@ -65,58 +63,6 @@ type ServicesData struct {
 	DisplayName string         `json:"display_name"`
 	Tenant      string         `json:"tenant"`
 	Projects    []ProjectsData `json:"projects"`
-}
-
-// convert from models.Services to structs.ServicesData
-// valuer
-func (s ServicesData) Value() (interface{}, error) {
-	return s, nil
-}
-
-func (s *ServicesData) Scan(value interface{}) error {
-	switch v := value.(type) {
-	case models.Services:
-		s.ID = v.ID
-		s.Name = v.Name
-		s.DisplayName = v.DisplayName
-		s.Tenant = v.Tenant
-		s.Projects = []ProjectsData{}
-		for _, p := range v.Projects {
-			s.Projects = append(s.Projects, ProjectsData{
-				ID:         p.ID,
-				ServiceID:  p.ServiceID,
-				Name:       p.Name,
-				Repo:       p.Repo,
-				DeployFile: p.DeployFile,
-				Namespace:  p.Namespace,
-				Branch:     p.Branch,
-			})
-		}
-		return nil
-	default:
-		return fmt.Errorf("invalid type for ServicesData")
-	}
-}
-
-func (p ProjectsData) Value() (interface{}, error) {
-	return p, nil
-}
-
-func (p *ProjectsData) Scan(value interface{}) error {
-	switch v := value.(type) {
-	case models.Projects:
-		p.ID = v.ID
-		p.ServiceID = v.ServiceID
-		p.Name = v.Name
-		p.Repo = v.Repo
-		p.DeployFile = v.DeployFile
-		p.Namespace = v.Namespace
-		p.Branch = v.Branch
-		fmt.Println(p)
-		return nil
-	default:
-		return fmt.Errorf("invalid type for ProjectsData")
-	}
 }
 
 type ExpandedServicesData struct {


### PR DESCRIPTION
Right now there are 2 sets of structs that are used throughout both the web layer and the database layer.  Sometimes these structs are used interchangeably within the code.  This normally shouldn't work (shouldn't even compile normally).  :)  The reason the compiler doesn't complain in this instance is that Gorm works with `interface{}` types.  In this case, it can't really tell that what it should be getting is pointer to a `model.Service` instance but instead its getting a pointer `structs.ServicesData`.

It looks to me like the database layer should only by using the structs from the `models` package.  The structs in the `structs` package appear to be used at the web/rest api layer.

First, I think the database layer needs to be modified so that it does not know about the `structs` package.

After that, I think there are 2 approaches that could be taken:

1) You use the structs from the `models` package at the web layer to marshal/unmarshal the data into json and remove the `structs` package.  This approach is less flexible.
2) You move the types from the `structs` package into web layer and only use these types at the web layer to marshal/unmarshal the data into json.  This approach is more flexible but you will need to write functions to convert from the db types into the web layer types.

Let me know if you'd like to discuss / talk this through  :)